### PR TITLE
Add back Shelters link in main nav

### DIFF
--- a/_data/navbar.yml
+++ b/_data/navbar.yml
@@ -1,4 +1,6 @@
 main-nav:
+  - title: Shelters
+    url: /
   - title: Distribution Points
     url: /distribution-map
   - title: About


### PR DESCRIPTION
Somehow the Shelters link in the main nav is missing. This adds it back.